### PR TITLE
Fix Void Snare apply behavior target unit reference

### DIFF
--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -731,7 +731,7 @@
     </CEffectEnumArea>
     <CEffectApplyBehavior id="MultiPlayerCollectionVoidSnareApply">
         <EditorCategories value="Race:Protoss"/>
-        <WhichUnit Value="TargetUnit"/>
+        <WhichUnit Value="Target"/>
         <Behavior value="MultiPlayerCollectionVoidSnarePrison"/>
     </CEffectApplyBehavior>
     <CEffectDestroyPersistent id="MultiPlayerCollectionVoidSnareDestroy">


### PR DESCRIPTION
## Summary
- ensure the Void Snare apply behavior references the valid target unit identifier

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68caa57a2fac832abd6742953a74eacf