### PR TITLE
Add warp harmony abilities for gateway units

### DIFF
--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -1045,7 +1045,7 @@
         <Cost>
             <Cooldown TimeUse="12"/>
         </Cost>
-        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <TargetFilters value="Visible;Enemy,Neutral,Destructible"/>
         <Range value="1.5"/>
         <Arc value="360"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionZealotHarmonyStrike"/>
@@ -1058,7 +1058,7 @@
         <Cost>
             <Cooldown TimeUse="14"/>
         </Cost>
-        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <TargetFilters value="Visible;Enemy,Neutral,Destructible"/>
         <Range value="6"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionStalkerHarmonyBolt"/>
@@ -1085,7 +1085,7 @@
             <Vital index="Energy" value="75"/>
             <Cooldown TimeUse="15"/>
         </Cost>
-        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <TargetFilters value="Visible;Enemy,Neutral,Destructible"/>
         <Range value="9"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionHighTemplarHarmonyStorm"/>
@@ -1098,7 +1098,7 @@
         <Cost>
             <Cooldown TimeUse="14"/>
         </Cost>
-        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <TargetFilters value="Visible;Enemy,Neutral,Destructible"/>
         <Range value="7"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionDarkTemplarHarmonyAmbush"/>
@@ -1111,7 +1111,7 @@
         <Cost>
             <Cooldown TimeUse="12"/>
         </Cost>
-        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <TargetFilters value="Visible;Enemy,Neutral,Destructible"/>
         <Range value="6"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionAdeptHarmonyEcho"/>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -1037,4 +1037,83 @@
         <EffectArray index="Finish" value="MultiPlayerCollectionOracleStasisTrapBuildBeamOff"/>
         <EffectArray index="Cancel" value="MultiPlayerCollectionOracleStasisTrapBuildBeamOff"/>
     </CAbilBuild>
+    <CAbilEffectTarget id="MultiPlayerCollectionZealotHarmonyStrike">
+        <Alignment value="Negative"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="MultiPlayerCollectionZealotHarmonyStrikeSet"/>
+        <Flags index="AllowMovement" value="1"/>
+        <Cost>
+            <Cooldown TimeUse="12"/>
+        </Cost>
+        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <Range value="1.5"/>
+        <Arc value="360"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionZealotHarmonyStrike"/>
+    </CAbilEffectTarget>
+    <CAbilEffectTarget id="MultiPlayerCollectionStalkerHarmonyBolt">
+        <Alignment value="Negative"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="MultiPlayerCollectionStalkerHarmonyBoltSet"/>
+        <Flags index="AllowMovement" value="1"/>
+        <Cost>
+            <Cooldown TimeUse="14"/>
+        </Cost>
+        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <Range value="6"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionStalkerHarmonyBolt"/>
+    </CAbilEffectTarget>
+    <CAbilEffectTarget id="MultiPlayerCollectionSentryHarmonyAnchor">
+        <Alignment value="Negative"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="MultiPlayerCollectionSentryHarmonyAnchorSearch"/>
+        <Flags index="AllowMovement" value="1"/>
+        <Cost>
+            <Vital index="Energy" value="50"/>
+            <Cooldown TimeUse="16"/>
+        </Cost>
+        <Range value="7"/>
+        <Arc value="360"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionSentryHarmonyAnchor"/>
+    </CAbilEffectTarget>
+    <CAbilEffectTarget id="MultiPlayerCollectionHighTemplarHarmonyStorm">
+        <Alignment value="Negative"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="MultiPlayerCollectionHighTemplarHarmonyStormSearch"/>
+        <Flags index="AllowMovement" value="1"/>
+        <Cost>
+            <Vital index="Energy" value="75"/>
+            <Cooldown TimeUse="15"/>
+        </Cost>
+        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <Range value="9"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionHighTemplarHarmonyStorm"/>
+    </CAbilEffectTarget>
+    <CAbilEffectTarget id="MultiPlayerCollectionDarkTemplarHarmonyAmbush">
+        <Alignment value="Negative"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="MultiPlayerCollectionDarkTemplarHarmonyAmbushSet"/>
+        <Flags index="AllowMovement" value="1"/>
+        <Cost>
+            <Cooldown TimeUse="14"/>
+        </Cost>
+        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <Range value="7"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionDarkTemplarHarmonyAmbush"/>
+    </CAbilEffectTarget>
+    <CAbilEffectTarget id="MultiPlayerCollectionAdeptHarmonyEcho">
+        <Alignment value="Negative"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="MultiPlayerCollectionAdeptHarmonyEchoSearch"/>
+        <Flags index="AllowMovement" value="1"/>
+        <Cost>
+            <Cooldown TimeUse="12"/>
+        </Cost>
+        <TargetFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <Range value="6"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="MultiPlayerCollectionAdeptHarmonyEcho"/>
+    </CAbilEffectTarget>
 </Catalog>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -1339,4 +1339,11 @@
             <VitalRegenArray index="Energy" value="0.2"/>
         </Modification>
     </CBehaviorBuff>
+    <CBehaviorBuff id="MultiPlayerCollectionWarpHarmonyMark">
+        <EditorCategories value="Race:Protoss"/>
+        <Alignment value="Negative"/>
+        <MaxStackCount value="5"/>
+        <Duration value="10"/>
+        <Icon value="Assets\\Textures\\BTN-Ability-Protoss-VoidRayPrismaticAlignment.dds"/>
+    </CBehaviorBuff>
 </Catalog>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -903,4 +903,34 @@
         <AlertIcon value="Assets\\Textures\\btn-building-protoss-shieldbattery.dds"/>
         <EditorCategories value="Race:Protoss"/>
     </CButton>
+    <CButton id="MultiPlayerCollectionZealotHarmonyStrike">
+        <Icon value="Assets\\Textures\\btn-ability-protoss-charge-color.dds"/>
+        <AlertIcon value="Assets\\Textures\\btn-ability-protoss-charge-color.dds"/>
+        <EditorCategories value="Race:Protoss"/>
+    </CButton>
+    <CButton id="MultiPlayerCollectionStalkerHarmonyBolt">
+        <Icon value="Assets\\Textures\\btn-ability-protoss-disruptionblast.dds"/>
+        <AlertIcon value="Assets\\Textures\\btn-ability-protoss-disruptionblast.dds"/>
+        <EditorCategories value="Race:Protoss"/>
+    </CButton>
+    <CButton id="MultiPlayerCollectionSentryHarmonyAnchor">
+        <Icon value="Assets\\Textures\\btn-ability-protoss-timewarp.dds"/>
+        <AlertIcon value="Assets\\Textures\\btn-ability-protoss-timewarp.dds"/>
+        <EditorCategories value="Race:Protoss"/>
+    </CButton>
+    <CButton id="MultiPlayerCollectionHighTemplarHarmonyStorm">
+        <Icon value="Assets\\Textures\\btn-ability-protoss-psistorm-color.dds"/>
+        <AlertIcon value="Assets\\Textures\\btn-ability-protoss-psistorm-color.dds"/>
+        <EditorCategories value="Race:Protoss"/>
+    </CButton>
+    <CButton id="MultiPlayerCollectionDarkTemplarHarmonyAmbush">
+        <Icon value="Assets\\Textures\\btn-unit-protoss-darktemplar.dds"/>
+        <AlertIcon value="Assets\\Textures\\btn-unit-protoss-darktemplar.dds"/>
+        <EditorCategories value="Race:Protoss"/>
+    </CButton>
+    <CButton id="MultiPlayerCollectionAdeptHarmonyEcho">
+        <Icon value="Assets\\Textures\\btn-ability-protoss-psionictransfer.dds"/>
+        <AlertIcon value="Assets\\Textures\\btn-ability-protoss-psionictransfer.dds"/>
+        <EditorCategories value="Race:Protoss"/>
+    </CButton>
 </Catalog>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -1666,4 +1666,134 @@
         <EffectArray value="MultiPlayerCollectionTempestWeaponGroundLM"/>
         <EffectArray value="MultiPlayerCollectionTempestFrenzyAB"/>
     </CEffectSet>
+    <CEffectApplyBehavior id="MultiPlayerCollectionWarpHarmonyApply">
+        <EditorCategories value="Race:Protoss"/>
+        <WhichUnit Value="Target"/>
+        <Behavior value="MultiPlayerCollectionWarpHarmonyMark"/>
+    </CEffectApplyBehavior>
+    <CEffectSet id="MultiPlayerCollectionWarpHarmonyApplyDouble">
+        <EditorCategories value="Race:Protoss"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyApply"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyApply"/>
+    </CEffectSet>
+    <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage1">
+        <EditorCategories value="Race:Protoss"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
+        <Amount value="10"/>
+    </CEffectDamage>
+    <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage2">
+        <EditorCategories value="Race:Protoss"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkTwo"/>
+        <Amount value="10"/>
+    </CEffectDamage>
+    <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage3">
+        <EditorCategories value="Race:Protoss"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkThree"/>
+        <Amount value="10"/>
+    </CEffectDamage>
+    <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage4">
+        <EditorCategories value="Race:Protoss"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkFour"/>
+        <Amount value="10"/>
+    </CEffectDamage>
+    <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage5">
+        <EditorCategories value="Race:Protoss"/>
+        <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkFive"/>
+        <Amount value="10"/>
+    </CEffectDamage>
+    <CEffectRemoveBehavior id="MultiPlayerCollectionWarpHarmonyRemoveAll">
+        <EditorCategories value="Race:Protoss"/>
+        <WhichUnit Value="Target"/>
+        <BehaviorLink value="MultiPlayerCollectionWarpHarmonyMark"/>
+        <RemoveAll value="1"/>
+    </CEffectRemoveBehavior>
+    <CEffectDamage id="MultiPlayerCollectionZealotHarmonyStrikeDamage">
+        <EditorCategories value="Race:Protoss"/>
+        <Kind value="Melee"/>
+        <Amount value="15"/>
+    </CEffectDamage>
+    <CEffectSet id="MultiPlayerCollectionZealotHarmonyStrikeSet">
+        <EditorCategories value="Race:Protoss"/>
+        <EffectArray value="MultiPlayerCollectionZealotHarmonyStrikeDamage"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyApply"/>
+    </CEffectSet>
+    <CEffectDamage id="MultiPlayerCollectionStalkerHarmonyBoltDamage">
+        <EditorCategories value="Race:Protoss"/>
+        <Kind value="Ranged"/>
+        <Amount value="15"/>
+    </CEffectDamage>
+    <CEffectSet id="MultiPlayerCollectionStalkerHarmonyBoltSet">
+        <EditorCategories value="Race:Protoss"/>
+        <EffectArray value="MultiPlayerCollectionStalkerHarmonyBoltDamage"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage1"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage2"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage3"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage4"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage5"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyRemoveAll"/>
+    </CEffectSet>
+    <CEffectEnumArea id="MultiPlayerCollectionSentryHarmonyAnchorSearch">
+        <EditorCategories value="Race:Protoss"/>
+        <ImpactLocation Value="TargetPoint"/>
+        <SearchFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <AreaArray Radius="3" Effect="MultiPlayerCollectionWarpHarmonyApplyDouble"/>
+        <SearchFlags index="ExtendByUnitRadius" value="1"/>
+    </CEffectEnumArea>
+    <CEffectDamage id="MultiPlayerCollectionHighTemplarHarmonyStormDamage">
+        <EditorCategories value="Race:Protoss"/>
+        <Kind value="Spell"/>
+        <Amount value="15"/>
+    </CEffectDamage>
+    <CEffectSet id="MultiPlayerCollectionHighTemplarHarmonyStormImpactSet">
+        <EditorCategories value="Race:Protoss"/>
+        <EffectArray value="MultiPlayerCollectionHighTemplarHarmonyStormDamage"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage1"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage2"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage3"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage4"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage5"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyRemoveAll"/>
+    </CEffectSet>
+    <CEffectEnumArea id="MultiPlayerCollectionHighTemplarHarmonyStormSearch">
+        <EditorCategories value="Race:Protoss"/>
+        <ImpactLocation Value="TargetUnit"/>
+        <SearchFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <AreaArray Radius="3" Effect="MultiPlayerCollectionHighTemplarHarmonyStormImpactSet"/>
+        <SearchFlags index="ExtendByUnitRadius" value="1"/>
+    </CEffectEnumArea>
+    <CEffectTeleport id="MultiPlayerCollectionDarkTemplarHarmonyAmbushTeleport">
+        <EditorCategories value="Race:Protoss"/>
+        <ValidatorArray value="CasterNotFungalGrowthed"/>
+        <WhichUnit Value="Caster"/>
+        <ClearQueuedOrders value="0"/>
+        <PlacementAround Value="TargetUnit"/>
+        <PlacementRange value="1"/>
+        <Range value="8"/>
+        <TargetLocation Value="TargetUnit"/>
+        <TeleportFlags index="TestCliff" value="1"/>
+        <TeleportFlags index="TestFog" value="1"/>
+    </CEffectTeleport>
+    <CEffectDamage id="MultiPlayerCollectionDarkTemplarHarmonyAmbushDamage">
+        <EditorCategories value="Race:Protoss"/>
+        <Kind value="Melee"/>
+        <Amount value="25"/>
+    </CEffectDamage>
+    <CEffectSet id="MultiPlayerCollectionDarkTemplarHarmonyAmbushSet">
+        <EditorCategories value="Race:Protoss"/>
+        <EffectArray value="MultiPlayerCollectionDarkTemplarHarmonyAmbushTeleport"/>
+        <EffectArray value="MultiPlayerCollectionDarkTemplarHarmonyAmbushDamage"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage1"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage2"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage3"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage4"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyBonusDamage5"/>
+        <EffectArray value="MultiPlayerCollectionWarpHarmonyRemoveAll"/>
+    </CEffectSet>
+    <CEffectEnumArea id="MultiPlayerCollectionAdeptHarmonyEchoSearch">
+        <EditorCategories value="Race:Protoss"/>
+        <ImpactLocation Value="TargetUnit"/>
+        <SearchFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <AreaArray MaxCount="3" Radius="4" Effect="MultiPlayerCollectionWarpHarmonyApply"/>
+        <SearchFlags index="ExtendByUnitRadius" value="1"/>
+    </CEffectEnumArea>
 </Catalog>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -1679,26 +1679,46 @@
     <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage1">
         <EditorCategories value="Race:Protoss"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyHasMark"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="10"/>
     </CEffectDamage>
     <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage2">
         <EditorCategories value="Race:Protoss"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkTwo"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="10"/>
     </CEffectDamage>
     <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage3">
         <EditorCategories value="Race:Protoss"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkThree"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="10"/>
     </CEffectDamage>
     <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage4">
         <EditorCategories value="Race:Protoss"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkFour"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="10"/>
     </CEffectDamage>
     <CEffectDamage id="MultiPlayerCollectionWarpHarmonyBonusDamage5">
         <EditorCategories value="Race:Protoss"/>
         <ValidatorArray value="MultiPlayerCollectionWarpHarmonyMarkFive"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="10"/>
     </CEffectDamage>
     <CEffectRemoveBehavior id="MultiPlayerCollectionWarpHarmonyRemoveAll">
@@ -1710,6 +1730,10 @@
     <CEffectDamage id="MultiPlayerCollectionZealotHarmonyStrikeDamage">
         <EditorCategories value="Race:Protoss"/>
         <Kind value="Melee"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="15"/>
     </CEffectDamage>
     <CEffectSet id="MultiPlayerCollectionZealotHarmonyStrikeSet">
@@ -1720,6 +1744,10 @@
     <CEffectDamage id="MultiPlayerCollectionStalkerHarmonyBoltDamage">
         <EditorCategories value="Race:Protoss"/>
         <Kind value="Ranged"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="15"/>
     </CEffectDamage>
     <CEffectSet id="MultiPlayerCollectionStalkerHarmonyBoltSet">
@@ -1735,13 +1763,17 @@
     <CEffectEnumArea id="MultiPlayerCollectionSentryHarmonyAnchorSearch">
         <EditorCategories value="Race:Protoss"/>
         <ImpactLocation Value="TargetPoint"/>
-        <SearchFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <SearchFilters value="Visible;Enemy,Neutral"/>
         <AreaArray Radius="3" Effect="MultiPlayerCollectionWarpHarmonyApplyDouble"/>
         <SearchFlags index="ExtendByUnitRadius" value="1"/>
     </CEffectEnumArea>
     <CEffectDamage id="MultiPlayerCollectionHighTemplarHarmonyStormDamage">
         <EditorCategories value="Race:Protoss"/>
         <Kind value="Spell"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="15"/>
     </CEffectDamage>
     <CEffectSet id="MultiPlayerCollectionHighTemplarHarmonyStormImpactSet">
@@ -1757,7 +1789,7 @@
     <CEffectEnumArea id="MultiPlayerCollectionHighTemplarHarmonyStormSearch">
         <EditorCategories value="Race:Protoss"/>
         <ImpactLocation Value="TargetUnit"/>
-        <SearchFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <SearchFilters value="Visible;Enemy,Neutral"/>
         <AreaArray Radius="3" Effect="MultiPlayerCollectionHighTemplarHarmonyStormImpactSet"/>
         <SearchFlags index="ExtendByUnitRadius" value="1"/>
     </CEffectEnumArea>
@@ -1776,6 +1808,10 @@
     <CEffectDamage id="MultiPlayerCollectionDarkTemplarHarmonyAmbushDamage">
         <EditorCategories value="Race:Protoss"/>
         <Kind value="Melee"/>
+        <ResponseFlags index="Acquire" value="1"/>
+        <ResponseFlags index="Flee" value="1"/>
+        <Flags index="Notification" value="1"/>
+        <SearchFlags index="CallForHelp" value="1"/>
         <Amount value="25"/>
     </CEffectDamage>
     <CEffectSet id="MultiPlayerCollectionDarkTemplarHarmonyAmbushSet">
@@ -1792,7 +1828,7 @@
     <CEffectEnumArea id="MultiPlayerCollectionAdeptHarmonyEchoSearch">
         <EditorCategories value="Race:Protoss"/>
         <ImpactLocation Value="TargetUnit"/>
-        <SearchFilters value="Visible;Self,Player,Ally,Neutral,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
+        <SearchFilters value="Visible;Enemy,Neutral"/>
         <AreaArray MaxCount="3" Radius="4" Effect="MultiPlayerCollectionWarpHarmonyApply"/>
         <SearchFlags index="ExtendByUnitRadius" value="1"/>
     </CEffectEnumArea>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -81,6 +81,7 @@
         <AbilArray Link="MultiPlayerCollectionWarpable"/>
         <AbilArray Link="MultiPlayerCollectionForceField"/>
         <AbilArray Link="MultiPlayerCollectionGuardianShield"/>
+        <AbilArray Link="MultiPlayerCollectionSentryHarmonyAnchor"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="BuildInProgress"/>
         <BehaviorArray Link="MultiPlayerCollectionSentryPsionicEfficiency"/>
@@ -94,6 +95,7 @@
             <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
+            <LayoutButtons Face="MultiPlayerCollectionSentryHarmonyAnchor" Type="AbilCmd" AbilCmd="MultiPlayerCollectionSentryHarmonyAnchor,Execute" Row="1" Column="0"/>
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="ProgressRally,Rally1" Row="1" Column="4"/>
             <LayoutButtons Face="MultiPlayerCollectionForceField" Type="AbilCmd" AbilCmd="MultiPlayerCollectionForceField,Execute" Row="2" Column="0"/>
             <LayoutButtons Face="MultiPlayerCollectionGuardianShield" Type="AbilCmd" AbilCmd="MultiPlayerCollectionGuardianShield,Execute" Row="2" Column="1"/>
@@ -548,6 +550,7 @@
         <AbilArray Link="stop"/>
         <AbilArray Link="move"/>
         <AbilArray Link="MultiPlayerCollectionPsiStorm"/>
+        <AbilArray Link="MultiPlayerCollectionHighTemplarHarmonyStorm"/>
         <AbilArray Link="MultiPlayerCollectionArchonWarp"/>
         <AbilArray Link="MultiPlayerCollectionWarpable"/>
         <AbilArray Link="ProgressRally"/>
@@ -564,6 +567,7 @@
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="AcquireMove" Type="AbilCmd" AbilCmd="move,AcquireMove" Row="0" Column="4"/>
+            <LayoutButtons Face="MultiPlayerCollectionHighTemplarHarmonyStorm" Type="AbilCmd" AbilCmd="MultiPlayerCollectionHighTemplarHarmonyStorm,Execute" Row="1" Column="0"/>
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="ProgressRally,Rally1" Row="2" Column="4"/>
             <LayoutButtons Face="MultiPlayerCollectionArchonWarpTarget" Type="AbilCmd" AbilCmd="MultiPlayerCollectionArchonWarp,SelectedUnits" Row="2" Column="3"/>
             <LayoutButtons Face="MultiPlayerCollectionPsiStorm" Type="AbilCmd" AbilCmd="MultiPlayerCollectionPsiStorm,Execute" Row="2" Column="1"/>
@@ -639,6 +643,7 @@
         <AbilArray Link="MultiPlayerCollectionArchonWarp"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="MultiPlayerCollectionDarkTemplarBlink"/>
+        <AbilArray Link="MultiPlayerCollectionDarkTemplarHarmonyAmbush"/>
         <BehaviorArray Link="MultiPlayerCollectionDTAssassinateOnHit"/>
         <BehaviorArray Link="MultiPlayerCollectionDarkTemplarAssassinStride"/>
         <BehaviorArray Link="MultiPlayerCollectionShieldBatteryRechargeEligible"/>
@@ -649,6 +654,7 @@
             <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
+            <LayoutButtons Face="MultiPlayerCollectionDarkTemplarHarmonyAmbush" Type="AbilCmd" AbilCmd="MultiPlayerCollectionDarkTemplarHarmonyAmbush,Execute" Row="1" Column="0"/>
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="ProgressRally,Rally1" Row="2" Column="4"/>
             <LayoutButtons Face="MultiPlayerCollectionArchonWarpSource" Type="AbilCmd" AbilCmd="MultiPlayerCollectionArchonWarp,SelectedUnits" Row="2" Column="3"/>
             <LayoutButtons Face="MultiPlayerCollectionDarkTemplarPermanentlyCloaked" Type="Passive" Row="2" Column="0"/>
@@ -1065,6 +1071,7 @@
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="MultiPlayerCollectionAdeptPhaseShift"/>
         <AbilArray Link="MultiPlayerCollectionAdeptPhaseShiftCancel"/>
+        <AbilArray Link="MultiPlayerCollectionAdeptHarmonyEcho"/>
         <BehaviorArray Link="MultiPlayerCollectionAdeptResonatingFocus"/>
         <BehaviorArray Link="MultiPlayerCollectionAdeptStride"/>
         <BehaviorArray Link="MultiPlayerCollectionAdeptShieldResonance"/>
@@ -1076,6 +1083,7 @@
             <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
+            <LayoutButtons Face="MultiPlayerCollectionAdeptHarmonyEcho" Type="AbilCmd" AbilCmd="MultiPlayerCollectionAdeptHarmonyEcho,Execute" Row="1" Column="0"/>
             <LayoutButtons Face="MultiPlayerCollectionAdeptPhaseShift" Type="AbilCmd" AbilCmd="MultiPlayerCollectionAdeptPhaseShift,Execute" Row="2" Column="0"/>
             <LayoutButtons Face="Cancel" Type="AbilCmd" AbilCmd="MultiPlayerCollectionAdeptPhaseShiftCancel,Execute" Row="2" Column="4"/>
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="ProgressRally,Rally1" Row="1" Column="4"/>
@@ -2523,6 +2531,7 @@
         <AbilArray Link="MultiPlayerCollectionWarpable"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="MultiPlayerCollectionCharge"/>
+        <AbilArray Link="MultiPlayerCollectionZealotHarmonyStrike"/>
         <BehaviorArray Link="MultiPlayerCollectionZealotBattleFocus"/>
         <BehaviorArray Link="MultiPlayerCollectionZealotWarMarch"/>
         <BehaviorArray Link="MultiPlayerCollectionZealotShieldResolve"/>
@@ -2535,6 +2544,7 @@
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="ProgressRally,Rally1" Row="2" Column="4"/>
+            <LayoutButtons Face="MultiPlayerCollectionZealotHarmonyStrike" Type="AbilCmd" AbilCmd="MultiPlayerCollectionZealotHarmonyStrike,Execute" Row="1" Column="0"/>
             <LayoutButtons Face="MultiPlayerCollectionCharge" Type="AbilCmd" AbilCmd="MultiPlayerCollectionCharge,Execute" Row="2" Column="0"/>
             <LayoutButtons Face="MultiPlayerCollectionZealotBattleFocus" Type="Passive" Behavior="MultiPlayerCollectionZealotBattleFocus" Row="2" Column="1"/>
             <LayoutButtons Face="MultiPlayerCollectionZealotWarMarch" Type="Passive" Behavior="MultiPlayerCollectionZealotWarMarch" Row="2" Column="2"/>
@@ -2607,6 +2617,7 @@
         <AbilArray Link="MultiPlayerCollectionWarpable"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="MultiPlayerCollectionBlink"/>
+        <AbilArray Link="MultiPlayerCollectionStalkerHarmonyBolt"/>
         <BehaviorArray Link="MultiPlayerCollectionStalkerPhaseOptimization"/>
         <BehaviorArray Link="MultiPlayerCollectionStalkerBlinkThrusters"/>
         <BehaviorArray Link="MultiPlayerCollectionStalkerShieldCalibration"/>
@@ -2618,6 +2629,7 @@
             <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
+            <LayoutButtons Face="MultiPlayerCollectionStalkerHarmonyBolt" Type="AbilCmd" AbilCmd="MultiPlayerCollectionStalkerHarmonyBolt,Execute" Row="1" Column="0"/>
             <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="ProgressRally,Rally1" Row="2" Column="4"/>
             <LayoutButtons Face="MultiPlayerCollectionBlink" Type="AbilCmd" AbilCmd="MultiPlayerCollectionBlink,Execute" Row="2" Column="0"/>
             <LayoutButtons Face="MultiPlayerCollectionStalkerPhaseOptimization" Type="Passive" Behavior="MultiPlayerCollectionStalkerPhaseOptimization" Row="2" Column="1"/>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -49,6 +49,36 @@
         <Compare value="GE"/>
         <Value value="1"/>
     </CValidatorUnitCompareBehaviorCount>
+    <CValidatorUnitCompareBehaviorCount id="MultiPlayerCollectionWarpHarmonyHasMark">
+        <WhichUnit Value="Target"/>
+        <Behavior value="MultiPlayerCollectionWarpHarmonyMark"/>
+        <Compare value="GE"/>
+        <Value value="1"/>
+    </CValidatorUnitCompareBehaviorCount>
+    <CValidatorUnitCompareBehaviorCount id="MultiPlayerCollectionWarpHarmonyMarkTwo">
+        <WhichUnit Value="Target"/>
+        <Behavior value="MultiPlayerCollectionWarpHarmonyMark"/>
+        <Compare value="GE"/>
+        <Value value="2"/>
+    </CValidatorUnitCompareBehaviorCount>
+    <CValidatorUnitCompareBehaviorCount id="MultiPlayerCollectionWarpHarmonyMarkThree">
+        <WhichUnit Value="Target"/>
+        <Behavior value="MultiPlayerCollectionWarpHarmonyMark"/>
+        <Compare value="GE"/>
+        <Value value="3"/>
+    </CValidatorUnitCompareBehaviorCount>
+    <CValidatorUnitCompareBehaviorCount id="MultiPlayerCollectionWarpHarmonyMarkFour">
+        <WhichUnit Value="Target"/>
+        <Behavior value="MultiPlayerCollectionWarpHarmonyMark"/>
+        <Compare value="GE"/>
+        <Value value="4"/>
+    </CValidatorUnitCompareBehaviorCount>
+    <CValidatorUnitCompareBehaviorCount id="MultiPlayerCollectionWarpHarmonyMarkFive">
+        <WhichUnit Value="Target"/>
+        <Behavior value="MultiPlayerCollectionWarpHarmonyMark"/>
+        <Compare value="GE"/>
+        <Value value="5"/>
+    </CValidatorUnitCompareBehaviorCount>
     <CValidatorUnitCompareBehaviorCount id="MultiPlayerCollectionNotHaveUpgradeToWarpGateAutoCastDisabler">
         <WhichUnit Value="Caster"/>
         <Behavior value="MultiPlayerCollectionUpgradeToWarpGateAutoCastDisabler"/>

--- a/MultiPlayerCollectionProtossStandAlone.SC2Mod/zhCN.SC2Data/LocalizedData/GameStrings.txt
+++ b/MultiPlayerCollectionProtossStandAlone.SC2Mod/zhCN.SC2Data/LocalizedData/GameStrings.txt
@@ -618,3 +618,24 @@ Weapon/Name/MultiPlayerCollectionPurifierBeamDummyTargetFire=火力分配标记
 Weapon/Name/MultiPlayerCollectionTempestWeaponAir=动能过载
 Weapon/Name/MultiPlayerCollectionTempestWeaponGround=谐振盘
 Weapon/Name/MultiPlayerCollectionVoidRayBeam=棱镜光束
+
+Behavior/Name/MultiPlayerCollectionWarpHarmonyMark=折跃共鸣标记
+Behavior/Tooltip/MultiPlayerCollectionWarpHarmonyMark=受到折跃门作战单位的共鸣技能影响，持续<d ref="Behavior,MultiPlayerCollectionWarpHarmonyMark,Duration"/>秒。可叠加至<d ref="Behavior,MultiPlayerCollectionWarpHarmonyMark,MaxStackCount"/>层，被其他共鸣技能消耗以触发额外效果。
+Abil/Name/MultiPlayerCollectionZealotHarmonyStrike=共鸣突袭
+Abil/Name/MultiPlayerCollectionStalkerHarmonyBolt=共鸣能量箭
+Abil/Name/MultiPlayerCollectionSentryHarmonyAnchor=共鸣定锚
+Abil/Name/MultiPlayerCollectionHighTemplarHarmonyStorm=共鸣风暴
+Abil/Name/MultiPlayerCollectionDarkTemplarHarmonyAmbush=共鸣伏击
+Abil/Name/MultiPlayerCollectionAdeptHarmonyEcho=共鸣回响
+Button/Name/MultiPlayerCollectionZealotHarmonyStrike=共鸣突袭
+Button/Tooltip/MultiPlayerCollectionZealotHarmonyStrike=狂热者对近战目标造成15点伤害并施加1层折跃共鸣标记，标记持续10秒。配合其他折跃共鸣技能可引爆额外效果。该技能每<d ref="Abil,MultiPlayerCollectionZealotHarmonyStrike,Cost.Cooldown.TimeUse"/>秒最多只能使用一次。
+Button/Name/MultiPlayerCollectionStalkerHarmonyBolt=共鸣能量箭
+Button/Tooltip/MultiPlayerCollectionStalkerHarmonyBolt=只能对带有折跃共鸣标记的敌人施放。造成15点基础伤害并消耗其全部标记，每层标记额外造成10点伤害。该技能每<d ref="Abil,MultiPlayerCollectionStalkerHarmonyBolt,Cost.Cooldown.TimeUse"/>秒最多只能使用一次。
+Button/Name/MultiPlayerCollectionSentryHarmonyAnchor=共鸣定锚
+Button/Tooltip/MultiPlayerCollectionSentryHarmonyAnchor=在目标位置展开共鸣力场，对范围内敌方单位施加2层折跃共鸣标记，帮助队伍快速连携。消耗<d ref="Abil,MultiPlayerCollectionSentryHarmonyAnchor,Cost.Vital[Energy].Value"/>点能量，冷却<d ref="Abil,MultiPlayerCollectionSentryHarmonyAnchor,Cost.Cooldown.TimeUse"/>秒。
+Button/Name/MultiPlayerCollectionHighTemplarHarmonyStorm=共鸣风暴
+Button/Tooltip/MultiPlayerCollectionHighTemplarHarmonyStorm=只能对折跃共鸣标记的单位施放。对目标及其附近敌人造成15点基础伤害，并为目标身上的每层标记额外造成10点伤害，之后清除所有标记。消耗<d ref="Abil,MultiPlayerCollectionHighTemplarHarmonyStorm,Cost.Vital[Energy].Value"/>点能量，冷却<d ref="Abil,MultiPlayerCollectionHighTemplarHarmonyStorm,Cost.Cooldown.TimeUse"/>秒。
+Button/Name/MultiPlayerCollectionDarkTemplarHarmonyAmbush=共鸣伏击
+Button/Tooltip/MultiPlayerCollectionDarkTemplarHarmonyAmbush=只能对带有折跃共鸣标记的敌人施放。瞬移至目标附近，造成25点基础伤害并移除其全部标记，每层标记额外造成10点伤害。该技能每<d ref="Abil,MultiPlayerCollectionDarkTemplarHarmonyAmbush,Cost.Cooldown.TimeUse"/>秒最多只能使用一次。
+Button/Name/MultiPlayerCollectionAdeptHarmonyEcho=共鸣回响
+Button/Tooltip/MultiPlayerCollectionAdeptHarmonyEcho=只能对折跃共鸣标记的敌人施放。刷新目标标记并将折跃共鸣标记扩散给其及附近最多两个敌人。该技能每<d ref="Abil,MultiPlayerCollectionAdeptHarmonyEcho,Cost.Cooldown.TimeUse"/>秒最多只能使用一次。


### PR DESCRIPTION
## Summary
- create a shared Warp Harmony mark behavior with stack-aware validators and supporting effects
- add new Harmony abilities for each gateway combat unit with appropriate buttons and command card hookups
- localize Chinese names and tooltips for the shared mechanic

## Testing
- not run (manual testing planned)

------
https://chatgpt.com/codex/tasks/task_e_68cbcf16a760832abb8b09c67f0ae540